### PR TITLE
Clean path during file map build instead of during tree build

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 )
 
@@ -27,16 +26,6 @@ var (
 		"Path to sandstorm keyring",
 	)
 )
-
-// wrapper around filepath.Dir that also canonicalizes the result.
-func dirname(name string) string {
-	return filepath.Clean(filepath.Dir(name))
-}
-
-// wrapper around filepath.Base that also canonicalizes the result.
-func basename(name string) string {
-	return filepath.Clean(filepath.Base(name))
-}
 
 // If the error is not nil, display an error message to the user based on
 // `context` and `err`, and exit the with a failing status.


### PR DESCRIPTION
If a path is cleaned, then the lookup during tree build fails and this causes unpredictable behavior in the SPK process. Cleaning paths as they come in simplifies the code and makes it more robust.

While I was here, switched to "path" instead of "path/filepath" since Docker/tar will always be using POSIX paths. Also removed some dead code.

Fixes #12